### PR TITLE
added new report: checkedout report. updated dashboard to include sev…

### DIFF
--- a/app/controllers/admin/DashboardController.php
+++ b/app/controllers/admin/DashboardController.php
@@ -16,8 +16,10 @@ class DashboardController extends AdminController
     {
         // Show the page
 
+		// need to add a limit clause to the query
+		$checkedout_tools = Actionlog::getListingOfCheckedOutItems();
+		
         $recent_activity = Actionlog::orderBy('created_at','DESC')->with('toollog','consumablelog','licenselog','assetlog','adminlog','userlog')->take(7)->get();
-
 
         $asset_stats['total'] = Asset::Hardware()->count();
 
@@ -65,7 +67,7 @@ class DashboardController extends AdminController
         }
 
 
-        return View::make('backend/dashboard')->with('asset_stats',$asset_stats)->with('recent_activity',$recent_activity);
+        return View::make('backend/dashboard')->with('asset_stats',$asset_stats)->with('recent_activity',$recent_activity)->with('checkedout_tools', $checkedout_tools);
     }
 
 }

--- a/app/controllers/admin/ReportsController.php
+++ b/app/controllers/admin/ReportsController.php
@@ -770,4 +770,18 @@ class ReportsController extends AdminController
 
         return Asset::unaccepted();
     }
+
+	/**
+	 * getCheckedOutReport
+	 *
+	 * @todo this function uses a static method in Actionlog, i can tell that
+	 * is incorrect somehow but havent decided the "eloquent" way to fix it
+	 */
+    public function getCheckedOutReport()
+    {
+
+		$log_checkedout = Actionlog::getListingOfCheckedOutItems();
+
+		return View::make( 'backend/reports/checkedout', compact( 'log_checkedout' ) );
+    }
 }

--- a/app/lang/en/general.php
+++ b/app/lang/en/general.php
@@ -1,9 +1,6 @@
 <?php
 
     return [
-    'tools'					=> 'Tools',
-    'tool'					=> 'Tool',
-    'tool_report'			=> 'Tool Report',
     'action'                => 'Action',
     'activity_report'		=> 'Activity Report',
     'address'				=> 'Address',
@@ -29,6 +26,7 @@
     'checkin'  				=> 'Checkin',
     'checkin_from'  		=> 'Checkin from',
     'checkout'  			=> 'Checkout',
+	'checkedout_report'		=> 'Checked Out Report',
     'city'  				=> 'City',
     'consumable'			=> 'Consumable',
     'consumables'			=> 'Consumables',
@@ -101,6 +99,7 @@
     'quanitity'		        => 'Quanitity',
     'ready_to_deploy'		=> 'Ready to Deploy',
     'recent_activity'		=> 'Recent Activity',
+	'recent_checkedout_items' => 'Recent Checkouts',
     'reports'				=> 'Reports',
     'requested'				=> 'Requested',
     'save'  				=> 'Save',
@@ -121,6 +120,9 @@
     'status_labels'			=> 'Status Labels',
     'status'    			=> 'Status',
     'suppliers'  			=> 'Suppliers',
+    'tool'					=> 'Tool',
+    'tool_report'			=> 'Tool Report',
+    'tools'					=> 'Tools',
     'total_assets'			=> 'total assets',
     'total_licenses'		=> 'total licenses',
     'type'  				=> 'Type',

--- a/app/routes.php
+++ b/app/routes.php
@@ -568,6 +568,10 @@
             [ 'as' => 'reports/unaccepted_assets', 'uses' => 'ReportsController@getAssetAcceptanceReport' ] );
         Route::get( 'reports/export/unaccepted_assets',
             [ 'as' => 'reports/export/unaccepted_assets', 'uses' => 'ReportsController@exportAssetAcceptanceReport' ] );
+		Route::get( 'reports/checkedout', 
+			[ 'as'	=> 'reports/checkedout',
+			  'uses'=> 'ReportsController@getCheckedOutReport' 
+			] );
     } );
 
     Route::get( '/',

--- a/app/views/backend/dashboard.blade.php
+++ b/app/views/backend/dashboard.blade.php
@@ -58,7 +58,7 @@
 					</td>
 					<td>
 						{{ $tool->note }}
-
+					</td>
 			    </tr>
 			   @endforeach
 			@endif

--- a/app/views/backend/dashboard.blade.php
+++ b/app/views/backend/dashboard.blade.php
@@ -28,6 +28,47 @@
         <br>
     </div>
     <div class="col-md-9 chart">
+        <h5>@lang('general.recent_checkedout_items') (<a href="{{ Config::get('app.url') }}/reports/checkedout">view all</a>)</h5>
+
+        <table class="table table-hover table-fixed break-word">
+			<thead>
+			    <tr>
+			        <th class="col-md-1"><span class="line"></span>@lang('general.date')</th>
+			        <th class="col-md-2"><span class="line"></span>@lang('general.item')</th>
+			        <th class="col-md-3"><span class="line"></span>@lang('general.type')</th>
+			        <th class="col-md-2"><span class="line"></span>@lang('general.user')</th>
+			        <th class="col-md-3"><span class="line"></span>@lang('general.notes')</th>
+			    </tr>
+			</thead>
+			<tbody>
+			@if (count($checkedout_tools) > 0)
+				@foreach (array_slice($checkedout_tools, 0, 5) as $tool)
+			    <tr>
+					<td>
+						{{{ date("M d", strtotime($tool->created_at)) }}}
+					</td>
+					<td>
+						{{ $tool->name }}
+					</td>
+					<td>
+						{{ $tool->tool_type }}
+					</td>
+					<td>
+						{{ $tool->first_name }} {{ $tool->last_name }}
+					</td>
+					<td>
+						{{ $tool->note }}
+
+			    </tr>
+			   @endforeach
+			@endif
+			</tbody>
+			</table>
+
+
+    </div>
+
+    <div class="col-md-9 chart">
         <h5>@lang('general.recent_activity') (<a href="{{ Config::get('app.url') }}/reports/activity">view all</a>)</h5>
 
         <table class="table table-hover table-fixed break-word">
@@ -87,37 +128,11 @@
 
 
     </div>
-    <div class="col-md-3 chart">
-        <h5>@lang('general.asset') @lang('general.status')</h5>
-        <div id="hero-assets" style="height: 250px;"></div>
-    </div>
-
-
 
 </div>
 
 
 
-<!-- build the charts -->
-    <script type="text/javascript">
-
-
-        // Morris Donut Chart
-        Morris.Donut({
-            element: 'hero-assets',
-            data: [
-	            {label: '@lang('general.ready_to_deploy')', value: {{ $asset_stats['rtd']['percent'] }} },
-                {label: '@lang('general.deployed')', value: {{ $asset_stats['deployed']['percent'] }} },
-                {label: '@lang('general.pending')', value: {{ $asset_stats['pending']['percent'] }} },
-                {label: '@lang('general.undeployable')', value: {{ $asset_stats['undeployable']['percent'] }} },
-                {label: '@lang('general.archived')', value: {{ $asset_stats['archived']['percent'] }} },
-            ],
-            colors: ["#30a1ec", "#76bdee", "#c4dafe"],
-            formatter: function (y) { return y + "%" }
-        });
-
-
-    </script>
 
 
 @stop

--- a/app/views/backend/layouts/default.blade.php
+++ b/app/views/backend/layouts/default.blade.php
@@ -342,6 +342,8 @@
                     <li><a href="{{ URL::to('reports/assets') }}" {{{ (Request::is('reports/assets') ? ' class="active"' : '') }}} >@lang('general.asset_report')</a></li>
                     <li><a href="{{ URL::to('reports/unaccepted_assets') }}" {{{ (Request::is('reports/unaccepted_assets') ? ' class="active"' : '') }}} >@lang('general.unaccepted_asset_report')</a></li>
 -->
+
+                    <li><a href="{{ URL::to('reports/checkedout') }}" {{{ (Request::is('reports/checkedout') ? ' class="active"' : '') }}} >@lang('general.checkedout_report')</a></li>
                     <li><a href="{{ URL::to('reports/tools') }}" {{{ (Request::is('reports/tools') ? ' class="active"' : '') }}} >@lang('general.tool_report')</a></li>
                     <li><a href="{{ URL::to('reports/custom') }}" {{{ (Request::is('reports/custom') ? ' class="active"' : '') }}} >@lang('general.custom_report')</a></li>
                 </ul>

--- a/app/views/backend/reports/checkedout.blade.php
+++ b/app/views/backend/reports/checkedout.blade.php
@@ -1,0 +1,58 @@
+@extends('backend/layouts/default')
+
+{{-- Page title --}}
+@section('title')
+@lang('general.checkedout_report') ::
+@parent
+@stop
+
+{{-- Page content --}}
+@section('content')
+
+
+<div class="page-header">
+
+    <h3>@lang('general.checkedout_report')</h3>
+</div>
+
+
+<div class="row">
+
+<div class="table-responsive">
+<table id="example">
+        <thead>
+            <tr role="row">
+            <th class="col-sm-1">@lang('general.date')</th>
+            <th class="col-sm-1">@lang('general.item')</th>
+            <th class="col-sm-1">@lang('general.type')</th>
+            <th class="col-sm-1">@lang('general.user')</th>
+            <th class="col-sm-1">@lang('general.notes')</th>
+        </tr>
+    </thead>
+    <tbody>
+
+        @foreach ($log_checkedout as $log_action)
+        <tr>
+            <td>
+				{{ date("M d G:i", strtotime($log_action->created_at)) }}
+			</td>
+			<td>
+				{{ $log_action->name }}
+			</td>
+            <td>
+				{{ $log_action->tool_type }}
+			</td>
+            <td>
+				{{ $log_action->first_name }} {{ $log_action->last_name }}
+			</td>
+            <td>
+				{{ $log_action->note }}
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+
+</div>
+
+@stop


### PR DESCRIPTION
…eral rows from report. this was at the request of a user.

several todo's:

app/models/Actionlog.php:

function getListingOfCheckedOutItems() is nearly a hack. it works but it is not the "eloquent" solution.
1) since most of the database is maintained by ORM maybe we should find an ORM solution opposed to using the query builder. although im not sure how i feel about ORM
2) at the very least this function should be broken up into each asset type's model: tool, gage, consumable, etc. current this pulls everything from each table, then performs a union.
3) there is no way to limit the number of results returned. the bashboard just slices the result set
